### PR TITLE
Add Linux brew support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Install Minio from brew
+# Install MinIO from brew
 
-Official [Homebrew](https://brew.sh/) packages for Minio.
+Official [Homebrew](https://brew.sh/) packages for MinIO.
 
-NOTE: [Linuxbrew](http://linuxbrew.sh/) is not officially supported.
+Official [Linuxbrew](http://linuxbrew.sh/) packages for MinIO.
 
-## Install Minio
+## Install MinIO
 
 ```sh
 brew install minio/stable/minio
 ```
 
-## Install Minio Client (mc)
+## Install MinIO Client (mc)
 
 ```sh
 brew install minio/stable/mc

--- a/mc.rb
+++ b/mc.rb
@@ -2,7 +2,7 @@ class Mc < Formula
   # mc specific
   git_tag = "RELEASE.2019-05-29T21-21-34Z"
 
-  desc "ls, cp, mkdir, diff and rsync for filesystems and object storage"
+  desc "MinIO Client for object storage and filesystems"
   homepage "https://github.com/minio/mc"
   url "https://github.com/minio/mc.git"
   version git_tag.gsub(%r'[^\d]+', '') + 'Z'
@@ -12,20 +12,17 @@ class Mc < Formula
     url "https://dl.minio.io/client/mc/release/darwin-amd64/mc.#{git_tag}"
     sha256 "30172968ee98171eb5f2745ea508f10c8fab8ad1ea944ca75000b17069dd9699"
   elsif OS.linux?
-    raise "No Linux support"
+    url "https://dl.minio.io/client/mc/release/linux-amd64/mc.#{git_tag}"
+    sha256 "74fac61c9f68a19ae2dedc78bc4a97fc77f319f46d3ab8ecdc966c6116f5c299"
   end
 
   bottle :unneeded
   depends_on :arch => :x86_64
 
-  conflicts_with "midnight-commander", :because => "Both install a `mc` binary"
+  conflicts_with "midnight-commander", :because => "Both install `mc` binary"
 
   def install
     bin.install Dir.glob("mc.*").first => "mc"
-  end
-
-  def post_install
-    (etc/"mc").mkpath
   end
 
   test do

--- a/minio.rb
+++ b/minio.rb
@@ -2,7 +2,7 @@ class Minio < Formula
   # minio specific
   git_tag = "RELEASE.2019-06-04T01-15-58Z"
 
-  desc "Amazon S3 compatible object storage server"
+  desc "MinIO is an Amazon S3 compatible object storage server"
   homepage "https://github.com/minio/minio"
   url "https://github.com/minio/minio.git"
   version git_tag.gsub(%r'[^\d]+', '') + 'Z'
@@ -12,7 +12,8 @@ class Minio < Formula
     url "https://dl.minio.io/server/minio/release/darwin-amd64/minio.#{git_tag}"
     sha256 "36ecd2477296b04263b9130119c566c7a4c40b57d4044c99745eda16846b5719"
   elsif OS.linux?
-    raise "No Linux support"
+    url "https://dl.minio.io/server/minio/release/linux-amd64/minio.#{git_tag}"
+    sha256 "c0c6d2fa8e53aa745d776cd7a7b31cec77c5521e8275bb8c01af96e306f19d15"
   end
 
   bottle :unneeded
@@ -20,48 +21,6 @@ class Minio < Formula
 
   def install
     bin.install Dir.glob("minio.*").first => "minio"
-  end
-
-  def post_install
-    (var/"minio").mkpath
-    (var/"log/minio").mkpath
-    (etc/"minio").mkpath
-  end
-
-  plist_options :manual => "minio server"
-
-  def plist; <<-EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-   <plist version="1.0">
-    <dict>
-      <key>KeepAlive</key>
-      <true/>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/minio</string>
-        <string>server</string>
-        <string>--config-dir=#{etc}/minio</string>
-        <string>--address=:9000</string>
-        <string>#{var}/minio</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/minio/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/minio/output.log</string>
-      <key>RunAtLoad</key>
-      <true/>
-    </dict>
-    </plist>
-    EOS
   end
 
   test do


### PR DESCRIPTION
This PR also cleans up macOS installation,
it removes creating unexpected directories
on host system. MinIO brew installation
shouldn't enforce such things. MinIO is meant
to be run as non-root.