### PR TITLE
Re-point download URL to the archive folder

### DIFF
--- a/mc.rb
+++ b/mc.rb
@@ -9,10 +9,10 @@ class Mc < Formula
   revision 1
 
   if OS.mac?
-    url "https://dl.minio.io/client/mc/release/darwin-amd64/mc.#{version}"
+    url "https://dl.minio.io/client/mc/release/darwin-amd64/archive/mc.#{version}"
     sha256 "f4950a8980d333170d4ba3b1551446bb42f4728c4ed98952c10069865c8c83ba"
   elsif OS.linux?
-    url "https://dl.minio.io/client/mc/release/linux-amd64/mc.#{version}"
+    url "https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.#{version}"
     sha256 "c6156d79af7d8b3b65a3a9ec89a027e3f617e212d73a495cebb18e038459c1aa"
   end
 

--- a/mc.rb
+++ b/mc.rb
@@ -1,6 +1,6 @@
 class Mc < Formula
   # mc specific
-  git_tag = "RELEASE.2021-05-12T01-29-06Z"
+  git_tag = "RELEASE.2021-05-12T03-10-11Z"
 
   desc "MinIO Client for object storage and filesystems"
   homepage "https://min.io"

--- a/mc.rb
+++ b/mc.rb
@@ -9,10 +9,10 @@ class Mc < Formula
   revision 1
 
   if OS.mac?
-    url "https://dl.minio.io/client/mc/release/darwin-amd64/archive/mc.#{version}"
+    url "https://dl.minio.io/client/mc/release/darwin-amd64/mc.#{version}"
     sha256 "f4950a8980d333170d4ba3b1551446bb42f4728c4ed98952c10069865c8c83ba"
   elsif OS.linux?
-    url "https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.#{version}"
+    url "https://dl.minio.io/client/mc/release/linux-amd64/mc.#{version}"
     sha256 "c6156d79af7d8b3b65a3a9ec89a027e3f617e212d73a495cebb18e038459c1aa"
   end
 


### PR DESCRIPTION
The latest version, `RELEASE.2021-05-12T01-29-06Z`, is absent from the main folder:
```
[macOS 11.3.1] $ brew upgrade minio/stable/mc
==> Upgrading 1 outdated package:
minio/stable/mc RELEASE.2021-04-22T17-40-00Z_1 -> RELEASE.2021-05-12T01-29-06Z_1
==> Upgrading minio/stable/mc RELEASE.2021-04-22T17-40-00Z_1 -> RELEASE.2021-05-12T01-29-06Z_1
==> Downloading https://dl.minio.io/client/mc/release/darwin-amd64/mc.RELEASE.2021-05-12T01-29-06Z
#=#=-#  #
curl: (22) The requested URL returned error: 404
Error: Failed to download resource "mc"
Download failed: https://dl.minio.io/client/mc/release/darwin-amd64/mc.RELEASE.2021-05-12T01-29-06Z```