### PR TITLE
Remove deprecated call to `bottle :unneeded`

### DIFF
--- a/minio.rb
+++ b/minio.rb
@@ -16,7 +16,6 @@ class Minio < Formula
     sha256 "35bfc106cc32a3a11dffced6778c768585064ba512fa636204e7d838583903e2"
   end
 
-  bottle :unneeded
   depends_on :arch => :x86_64
 
   def install


### PR DESCRIPTION
When running `brew install minio/stable/mc` the following warning is produced:

```sh
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the minio/stable tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/minio/homebrew-stable/mc.rb:19
```

This removes the deprecated call, per the warning message instructions.