### PR TITLE
remove deprecated bottle :unneeded

### DIFF
--- a/mc.rb
+++ b/mc.rb
@@ -16,7 +16,6 @@ class Mc < Formula
     sha256 "aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93"
   end
 
-  bottle :unneeded
   depends_on :arch => :x86_64
 
   conflicts_with "midnight-commander", :because => "Both install `mc`"

--- a/minio.rb
+++ b/minio.rb
@@ -16,7 +16,6 @@ class Minio < Formula
     sha256 "35bfc106cc32a3a11dffced6778c768585064ba512fa636204e7d838583903e2"
   end
 
-  bottle :unneeded
   depends_on :arch => :x86_64
 
   def install


### PR DESCRIPTION
When installing or updating something with Homebrew, one gets the following warning:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the minio/stable tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/minio/homebrew-stable/mc.rb:19
```

This is due to the fact, that `bottle :unneeded` is deprecated without a replacement:
https://github.com/Homebrew/brew/pull/11239

After this PR the corresponding line will be removed from the formula.