### PR TITLE
Add support for Apple Silicon

### DIFF
--- a/mc.rb
+++ b/mc.rb
@@ -9,15 +9,19 @@ class Mc < Formula
   revision 1
 
   if OS.mac?
-    url "https://dl.minio.io/client/mc/release/darwin-amd64/archive/mc.#{version}"
-    sha256 "100c5b1185e8a28d44fa00d1532b6c2ef44e0c57f476e36d7e7dbfc46ed1f658"
+    if Hardware::CPU.arm?
+      url "https://dl.minio.io/client/mc/release/darwin-arm64/mc.#{version}"
+      sha256 "3d25ab5da5959fcf2339203881faeaae2fe606f2e55a716b20e13a7628673589"
+    else
+      url "https://dl.minio.io/client/mc/release/darwin-amd64/archive/mc.#{version}"
+      sha256 "100c5b1185e8a28d44fa00d1532b6c2ef44e0c57f476e36d7e7dbfc46ed1f658"
+    end
   elsif OS.linux?
     url "https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.#{version}"
     sha256 "aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93"
   end
 
   bottle :unneeded
-  depends_on :arch => :x86_64
 
   conflicts_with "midnight-commander", :because => "Both install `mc`"
 

--- a/minio.rb
+++ b/minio.rb
@@ -9,14 +9,17 @@ class Minio < Formula
   revision 1
 
   if OS.mac?
-    url "https://dl.minio.io/server/minio/release/darwin-amd64/archive/minio.#{version}"
-    sha256 "e99b1a251e67c3aa5ca65767cd221e66dc7e2d9b622ef4da442d1723b6d7ec7b"
+    if Hardware::CPU.arm?
+      url "https://dl.minio.io/server/minio/release/darwin-arm64/minio.#{version}"
+      sha256 "7bd6af2fb86be6be482a8c71fb812da4223606dcea69d7d810787d4aacc1386e"
+    else
+      url "https://dl.minio.io/server/minio/release/darwin-amd64/archive/minio.#{version}"
+      sha256 "e99b1a251e67c3aa5ca65767cd221e66dc7e2d9b622ef4da442d1723b6d7ec7b"
+    end
   elsif OS.linux?
     url "https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.#{version}"
     sha256 "35bfc106cc32a3a11dffced6778c768585064ba512fa636204e7d838583903e2"
   end
-
-  depends_on :arch => :x86_64
 
   def install
     bin.install Dir.glob("minio.*").first => "minio"


### PR DESCRIPTION
Adds support for installing ARM builds on ARM based Macs.

Resolves https://github.com/minio/minio/issues/13522