### PR TITLE
remove `bottle :unneded` in `mc.rb`

### DIFF
--- a/mc.rb
+++ b/mc.rb
@@ -21,8 +21,6 @@ class Mc < Formula
     sha256 "aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93"
   end
 
-  bottle :unneeded
-
   conflicts_with "midnight-commander", :because => "Both install `mc`"
 
   def install


### PR DESCRIPTION
Replaces https://github.com/minio/homebrew-stable/pull/39, which I accidentally closed.

I missed this file in https://github.com/minio/homebrew-stable/pull/36.

```
When running brew install minio/stable/mc the following warning is produced:

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the minio/stable tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/minio/homebrew-stable/mc.rb:19
This removes the deprecated call, per the warning message instructions.
```